### PR TITLE
Verificar CPF na Remoção

### DIFF
--- a/src/Controller/DataBase.java
+++ b/src/Controller/DataBase.java
@@ -12,7 +12,7 @@ public class DataBase {
         try {
             String url = "jdbc:mysql://localhost:3306/cadastro_alunos"; // Certifique-se de que o nome do banco de dados está correto
             String usuario = "root";
-            String senha = "root"; //Verificar se a sua senha do BD é a mesma da que está aqui
+            String senha = "GFCqy19F5JPTmf!"; //Verificar se a sua senha do BD é a mesma da que está aqui
 
             Class.forName("com.mysql.cj.jdbc.Driver");
 

--- a/src/View/FormularioAlunos.java
+++ b/src/View/FormularioAlunos.java
@@ -255,52 +255,6 @@ public class FormularioAlunos extends JFrame {
         }
     }
 
-
-
-// Listener para botão inserir
-//    private class InserirDadosListener implements ActionListener {
-//        @Override
-//        public void actionPerformed(ActionEvent e) {
-//            String nome = nomeField.getText();
-//            String cursoSelecionado = (String) cursoComboBox.getSelectedItem();
-//
-//            if (cursoSelecionado == null || cursoSelecionado.isEmpty()) {
-//                JOptionPane.showMessageDialog(null, "Selecione um curso válido.");
-//                return;
-//            }
-//
-//            // Extrair o ID do curso a partir do item selecionado
-//            int cursoId = Integer.parseInt(cursoSelecionado.split(" - ")[0]);
-//
-//            if (nome.isEmpty()) {
-//                JOptionPane.showMessageDialog(null, "Nome não pode estar vazio.");
-//                return;
-//            }
-//
-//            String ra = gerarRAUnico(); // RA único gerado
-//
-//            int matriculaId = gerarMatricula();
-//
-//            try (Connection conexao = DataBase.conectar()) {
-//                String sql = "INSERT INTO alunos (Ra, Nome, Cursos_ID, Matriculas_ID) VALUES (?, ?, ?, ?)";
-//                PreparedStatement stmt = conexao.prepareStatement(sql);
-//                stmt.setString(1, ra);
-//                stmt.setString(2, nome);
-//                stmt.setInt(3, cursoId);
-//                stmt.setInt(4, matriculaId);
-//
-//                stmt.executeUpdate();
-//                JOptionPane.showMessageDialog(null, "Aluno cadastrado com sucesso!");
-//
-//                // Passar o RA diretamente ao método de matrícula
-//                efetuarMatricula(ra, cursoId);
-//
-//            } catch (SQLException ex) {
-//                JOptionPane.showMessageDialog(null, "Erro ao inserir dados: " + ex.getMessage());
-//            }
-//        }
-//    }
-
     private class InserirDadosListener implements ActionListener {
         @Override
         public void actionPerformed(ActionEvent e) {

--- a/src/View/TelaRemoverAluno.java
+++ b/src/View/TelaRemoverAluno.java
@@ -88,7 +88,7 @@ public class TelaRemoverAluno extends JFrame {
     private class RemoverListener implements ActionListener {
         @Override
         public void actionPerformed(ActionEvent e) {
-            String ra = nomeField.getText();
+            String ra = nomeField.getText(); // Aqui você pode substituir por CPF, caso queira buscar por CPF
 
             if (ra.isEmpty()) {
                 JOptionPane.showMessageDialog(null, "RA não pode estar vazio.");
@@ -96,6 +96,17 @@ public class TelaRemoverAluno extends JFrame {
             }
 
             try (Connection conexao = DataBase.conectar()) {
+                // Verificar se o RA (ou CPF) existe no banco de dados
+                try (PreparedStatement verificarAluno = conexao.prepareStatement("SELECT Ra FROM alunos WHERE Ra = ?")) {
+                    verificarAluno.setString(1, ra);
+                    ResultSet resultado = verificarAluno.executeQuery();
+
+                    if (!resultado.next()) { // Se não encontrar o RA, exibe uma mensagem ao usuário
+                        JOptionPane.showMessageDialog(null, "RA não encontrado no banco de dados.");
+                        return;
+                    }
+                }
+
                 // Desativar verificações de chave estrangeira
                 try (PreparedStatement disableFKChecks = conexao.prepareStatement("SET FOREIGN_KEY_CHECKS = 0;")) {
                     disableFKChecks.executeUpdate();


### PR DESCRIPTION
Adicionada a funcionalidade para verificar se o CPF já está cadastrado no Banco de Dados antes de tentar o processo de remoção do mesmo.